### PR TITLE
Allow users to add timezone information

### DIFF
--- a/app/controllers/accounts_controller.rb
+++ b/app/controllers/accounts_controller.rb
@@ -1,6 +1,10 @@
 class AccountsController < ApplicationController
   skip_before_action :authenticate_user!, only: [:new, :create]
+
   def settings
+    respond_to do |format|
+      format.html
+    end
   end
 
   def cashflow_trend

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -17,7 +17,9 @@ class ApplicationController < ActionController::Base
 
   def configure_permitted_parameters
     devise_parameter_sanitizer.permit(:sign_up) { |u| u.permit(:full_name, :email, :password, :avatar)}
-    devise_parameter_sanitizer.permit(:account_update) { |u| u.permit(:full_name, :email, :password, :current_password, :password_confirmation, :avatar)}
+    devise_parameter_sanitizer.permit(:account_update) {
+      |u| u.permit(:full_name, :email, :password, :current_password, :password_confirmation, :avatar, :time_zone)
+    }
   end
 
   def current_account

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -19,4 +19,22 @@ class UsersController < ApplicationController
     @user.send_invitation_message(current_user.full_name)
     redirect_to(accounts_settings_path, notice: "An invitation has been sent to #{@user.email}.")
   end
+
+  def update
+    if current_user.update(user_params)
+      flash[:notice_header] = 'Profile updated'
+      flash[:notice] = "Your profile settings were successfully updated."
+      redirect_to(accounts_settings_path, notice: "Your profile settings were successfully updated.")
+    else
+      flash[:alert_header] = 'Profile not updated'
+      flash[:alert] = "Your profile settings were not updated. Please check your entries and try again."
+      redirect_to(accounts_settings_path)
+    end
+  end
+
+  private
+
+  def user_params
+    params.require(:user).permit(:full_name, :email, :time_zone)
+  end
 end

--- a/app/views/shared/_toast_messages.html.erb
+++ b/app/views/shared/_toast_messages.html.erb
@@ -13,7 +13,7 @@
 <% end %>
 <% if alert %>
 <div class="toast" role="alert" aria-live="assertive" aria-atomic="true">
-  <div class="toast-header primary">
+  <div class="toast-header danger">
     <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" class="me-1">
       <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
     </svg>

--- a/app/views/users/_profile_form.html.erb
+++ b/app/views/users/_profile_form.html.erb
@@ -1,5 +1,5 @@
-<%= form_for(current_user, :as => :user, :url => registration_path(:user),
-  :html => { :method => :put, class: 'form-horizontal' }) do |f| %>
+<%= form_for(current_user,:html => { :method => :put, class: 'form-horizontal', remote: true }) do |f| %>
+<%= render 'shared/error_messages', object: current_user %>
 <div class="mb-3 col-sm-8">
   <%= f.label :full_name, 'Name', class: 'control-label form-label med bold-2' %>
   <div>
@@ -15,25 +15,9 @@
 </div>
 
 <div class="mb-3 col-sm-8">
-  <%= f.label :current_password, 'Your current password', class: 'form-label control-label med bold-2' %>
+  <%= f.label :time_zone, 'Time zone', class: 'form-label control-label med bold-2' %>
   <div>
-    <%= f.password_field :current_password, :autocomplete => "current-password", class: 'form-control' %>
-  </div>
-</div>
-
-<div class="mb-3 col-sm-8">
-  <%= f.label :password, 'Create a new password', class: 'form-label control-label med bold-2' %>
-  <div>
-    <%= f.password_field :password, :autocomplete => "new-password", class: 'form-control' %>
-  </div>
-  <span class="small">Make sure your password is at least 8 characters.</span>
-
-</div>
-
-<div class="mb-3 col-sm-8">
-  <%= f.label :password_confirmation, 'Confirm your new password', class: 'form-label control-label med bold-2' %>
-  <div>
-    <%= f.password_field :password_confirmation, :autocomplete => "new-password", class: 'form-control' %>
+    <%= f.time_zone_select :time_zone, ActiveSupport::TimeZone.us_zones, {}, class: 'form-select' %>
   </div>
 </div>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -48,6 +48,7 @@ Rails.application.routes.draw do
     get 'accounts/cashflow_trend'
 
     #users resources
+    resources :users, only: [:update]
     post '/users/invite_person'
     post '/users/:id/reinvite', to: 'users#reinvite', as: :reinvite_user
     authenticate :user, lambda {|u| u.admin? } do


### PR DESCRIPTION
Users can now set their timezone information from within settings page. Also removed the ability to update your password. We will let them just reset the password.