### PR TITLE
Fetch transactions after link activation

### DIFF
--- a/app/controllers/plaid_controller.rb
+++ b/app/controllers/plaid_controller.rb
@@ -4,6 +4,7 @@ class PlaidController < ApplicationController
   def update_link
     @login_item = current_user.login_items.find_by(link_token: params['link_token'])
     @login_item.activate
+    @login_item.enqueue_transaction_fetch
     flash[:notice_header] = 'Link updated'
     flash[:notice] = "Your link to #{@login_item.institution.name} has been renewed successfully."
   end

--- a/app/jobs/refresh_transactions_job.rb
+++ b/app/jobs/refresh_transactions_job.rb
@@ -1,0 +1,8 @@
+class RefreshTransactionsJob < ApplicationJob
+  queue_as :transactions
+
+  def perform(access_token, user_id, start_date, end_date)
+    Rails.logger.info("[ResqueJob][RefreshTransactionsJob] Fetching transactions")
+    PlaidTransactionsCreator.call(access_token, User.find(user_id), start_date, end_date)
+  end
+end

--- a/app/models/login_item.rb
+++ b/app/models/login_item.rb
@@ -47,6 +47,14 @@ class LoginItem < ApplicationRecord
 
   def activate
     update(expired: false, expired_at: nil, link_token: nil, link_token_expires_at: nil)
+    #TODO email user
+  end
+
+  def enqueue_transaction_fetch
+    last_transaction_date = transactions_history_period[1] || self.created_at.to_date
+    last_webhook_date = self.last_webhook_sent_at.to_date || self.created_at.to_date
+    start_date = [last_webhook_date, last_transaction_date].min
+    RefreshTransactionsJob.perform_later(self.plaid_access_token, self.user_id, start_date.iso8601, Date.today.iso8601)
   end
 
   def fetch_link_token

--- a/app/services/login_item_event_processor.rb
+++ b/app/services/login_item_event_processor.rb
@@ -15,13 +15,14 @@ class LoginItemEventProcessor < EventProcessor
       case event_code
       when WEBHOOK_UPDATE_ACKNOWLEDGED_CODE
         Rails.logger.info("LoginItem webhook updated to #{metadata['new_webhook_url']}")
+        return true
       when PENDING_EXPIRATION_CODE
         Rails.logger.info("Item access consent expiring at #{metadata['consent_expiration_time']}")
         update_consent_expiration(metadata['consent_expiration_time'])
         # TODO EMAIL the user
-      when ERROR
+      when ERROR_CODE
         Rails.logger.info("Error with login item. #{metadata['error']}")
-        update_login_expiration
+        login_item.expire
         # TODO EMAIL the user
       else
         Rails.logger.error("Unable to process login item event code = #{event_code}")
@@ -32,10 +33,6 @@ class LoginItemEventProcessor < EventProcessor
 
   def update_consent_expiration(expires_at)
     login_item.update(consent_expires_at: DateTime.rfc3339(expires_at)&.utc)
-  end
-
-  def update_login_expiration
-    login_item.expire
   end
 end
 

--- a/spec/jobs/refresh_transactions_job_spec.rb
+++ b/spec/jobs/refresh_transactions_job_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe RefreshTransactionsJob, type: :job do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/login_item_spec.rb
+++ b/spec/models/login_item_spec.rb
@@ -34,4 +34,17 @@ RSpec.describe LoginItem, type: :model do
       expect(login_item.link_token_expires_at).to eq DateTime.parse(expired_at)
     end
   end
+
+  describe '#fetch_transactions_after_activation' do
+    it 'fetches transactions' do
+      login_item = create(:login_item, last_webhook_sent_at: Time.zone.now - 1.month)
+      expect(RefreshTransactionsJob).to receive(:perform_later).with(
+        login_item.plaid_access_token,
+        login_item.user_id,
+        login_item.last_webhook_sent_at.to_date.iso8601,
+        Date.today.iso8601,
+      )
+      login_item.enqueue_transaction_fetch
+    end
+  end
 end

--- a/spec/services/login_item_event_processor_spec.rb
+++ b/spec/services/login_item_event_processor_spec.rb
@@ -1,0 +1,43 @@
+require 'rails_helper'
+
+RSpec.describe LoginItemEventProcessor do
+  before(:all) do
+    @login_item = create(:login_item)
+  end
+
+  let(:metadata) {
+    {
+      new_webhook_url: 'http://webhook.dev',
+      'consent_expiration_time' => '2019-10-12T07:20:50.52Z'
+    }
+  }
+  it 'processes webhook update acknowledged event' do
+    expect(LoginItem.find(@login_item.id).last_webhook_code_sent).to be_nil
+    expect(LoginItem.find(@login_item.id).last_webhook_sent_at).to be_nil
+    LoginItemEventProcessor.call(LoginItemEventProcessor::WEBHOOK_UPDATE_ACKNOWLEDGED_CODE, @login_item.plaid_item_id, metadata)
+    expect(LoginItem.find(@login_item.id).last_webhook_code_sent).to eq(LoginItemEventProcessor::WEBHOOK_UPDATE_ACKNOWLEDGED_CODE)
+    expect(LoginItem.find(@login_item.id).last_webhook_sent_at).not_to be_nil
+  end
+
+  it 'processes pending expiration event' do
+    expect(LoginItem.find(@login_item.id).last_webhook_code_sent).to be_nil
+    expect(LoginItem.find(@login_item.id).last_webhook_sent_at).to be_nil
+    expect(LoginItem.find(@login_item.id).consent_expires_at).to be_nil
+    LoginItemEventProcessor.call(LoginItemEventProcessor::PENDING_EXPIRATION_CODE, @login_item.plaid_item_id, metadata)
+    expect(LoginItem.find(@login_item.id).last_webhook_code_sent).to eq(LoginItemEventProcessor::PENDING_EXPIRATION_CODE)
+    expect(LoginItem.find(@login_item.id).last_webhook_sent_at).not_to be_nil
+    expect(LoginItem.find(@login_item.id).consent_expires_at).not_to be_nil
+  end
+
+  it 'processes error event' do
+    expect(LoginItem.find(@login_item.id).last_webhook_code_sent).to be_nil
+    expect(LoginItem.find(@login_item.id).last_webhook_sent_at).to be_nil
+    expect(LoginItem.find(@login_item.id).expired).to eq(false)
+    expect(LoginItem.find(@login_item.id).expired_at).to be_nil
+    LoginItemEventProcessor.call(LoginItemEventProcessor::ERROR_CODE, @login_item.plaid_item_id, metadata)
+    expect(LoginItem.find(@login_item.id).last_webhook_code_sent).to eq(LoginItemEventProcessor::ERROR_CODE)
+    expect(LoginItem.find(@login_item.id).last_webhook_sent_at).not_to be_nil
+    expect(LoginItem.find(@login_item.id).expired).to eq(true)
+    expect(LoginItem.find(@login_item.id).expired_at).not_to be_nil
+  end
+end


### PR DESCRIPTION
There was a bug in the item event processor which was preventing the link to be marked as expired. That has been fixed. Also, added a way for us to fetch transactions once the link has been updated as well. Added some specs too.