### PR TITLE
Build dates independent of user timezones for charts

### DIFF
--- a/app/javascript/controllers/charts_controller.js
+++ b/app/javascript/controllers/charts_controller.js
@@ -356,6 +356,7 @@ export default class extends Controller {
     })
     .then(response => response.json())
     .then(data_json => {
+      console.debug(data_json)
       const balanceTrend = Object.entries(data_json['balances']).map(function(item) {
         return { x: self.convertDate(item[0]).toDateString(), y: item[1] }
       });
@@ -379,6 +380,7 @@ export default class extends Controller {
     })
     .then(response => response.json())
     .then(data_json => {
+      console.debug(data_json)
       const assetsTrend = Object.entries(data_json['assets_trend']).map(function(item) {
         return { x: self.convertDate(item[0]).toDateString(), y: item[1] }
       });
@@ -404,6 +406,7 @@ export default class extends Controller {
     })
     .then(response => response.json())
     .then(data_json => {
+      console.debug(data_json)
       const incomeTrend = Object.entries(data_json['income_trend']).map(function(item) {
         return { x: self.convertDate(item[0]).toDateString(), y: item[1] }
       });

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -100,6 +100,10 @@ class Account < ApplicationRecord
     aggregated_daily_balances_for_accounts(bank_accounts.assets.illiquid_accounts.includes([:balances]))
   end
 
+  def first_transaction_occured_at
+    transactions&.last&.occured_at || Date.today
+  end
+
   private
 
   def aggregated_daily_balances_for_accounts(accounts)

--- a/app/services/stat_calculator.rb
+++ b/app/services/stat_calculator.rb
@@ -60,7 +60,7 @@ class StatCalculator < ApplicationService
 
   def generate_aggregated_transactions_by_month_trend(transactions)
     transactions_by_month = transactions.group_by { |tx| tx.occured_at.beginning_of_month }
-    start_month = transactions_by_month.keys.first
+    start_month = @account.first_transaction_occured_at.beginning_of_month
     trend_data = {}
     if start_month
       while(start_month <= Date.today.beginning_of_month)

--- a/spec/models/account_spec.rb
+++ b/spec/models/account_spec.rb
@@ -83,4 +83,17 @@ RSpec.describe Account, type: :model do
     dba_balance3 = create(:balance, created_at: time_in_past + 2.day, current: 2000, bank_account: dba, user: shubham)
     expect(account.assets_trend.count).to eq 6
   end
+
+  it 'gives the first_transaction_occured_at' do
+    time_in_past = 5.days.ago
+    account = create(:account, created_at: time_in_past)
+    shubham = create(:user, account: account)
+    deepti = create(:user, account: account)
+    sba = create(:bank_account, created_at: time_in_past, account_type: 'investment', user: shubham)
+    create(:transaction, occured_at: time_in_past, amount: 100, user: shubham, bank_account: sba)
+    expect(account.first_transaction_occured_at).to eq time_in_past.to_date
+    time_in_past = 10.days.ago
+    create(:transaction, occured_at: time_in_past, amount: 100, user: shubham, bank_account: sba)
+    expect(account.first_transaction_occured_at).to eq time_in_past.to_date
+  end
 end

--- a/spec/services/expenses_calculator_spec.rb
+++ b/spec/services/expenses_calculator_spec.rb
@@ -2,14 +2,16 @@ require 'rails_helper'
 
 RSpec.describe ExpensesCalculator do
   before('all') do
-    @user = create(:user)
+    @account = create(:account)
+    @user = create(:user, account: @account)
     @category = create(:category, plaid_category_id: Category::CC_PAYMENT_PLAID_ID)
     build_historical_transactions
   end
 
   it 'calculates the income historical trend' do
     historical_trend_data = ExpensesCalculator.call(@user.account)[:historical_trend_data]
-    expect(historical_trend_data.keys.count).to eq(13)
+    expect(historical_trend_data.keys.count).to eq(25)
+    expect(historical_trend_data.keys.first).to eq @account.first_transaction_occured_at.beginning_of_month
     this_month = Date.today.beginning_of_month
     expect(historical_trend_data[this_month]).to eq(100)
     expect(historical_trend_data[this_month - 1.month]).to eq(100)
@@ -18,6 +20,7 @@ RSpec.describe ExpensesCalculator do
     expect(historical_trend_data[this_month - 4.month]).to eq(400)
     expect(historical_trend_data[this_month - 5.month]).to eq(0)
     expect(historical_trend_data[this_month - 1.year]).to eq(500)
+    expect(historical_trend_data[this_month - 2.year]).to eq(0)
   end
 
   it 'has a current value' do
@@ -47,5 +50,6 @@ RSpec.describe ExpensesCalculator do
     create(:transaction, occured_at: 3.month.ago, amount: 100, user: @user)
     create(:transaction, occured_at: 4.month.ago, amount: 400, user: @user)
     create(:transaction, occured_at: 1.year.ago, amount: 500, user: @user)
+    create(:transaction, occured_at: 2.year.ago, amount: -500, user: @user)
   end
 end

--- a/spec/services/income_calculator_spec.rb
+++ b/spec/services/income_calculator_spec.rb
@@ -2,14 +2,16 @@ require 'rails_helper'
 
 RSpec.describe IncomeCalculator do
   before('all') do
-    @user = create(:user)
+    @account = create(:account)
+    @user = create(:user, account: @account)
     @category = create(:category, plaid_category_id: Category::INTERNAL_ACCOUNT_TRANSFER_PLAID_ID)
     build_historical_transactions
   end
 
   it 'calculates the income historical trend' do
-    historical_trend_data = IncomeCalculator.call(@user.account)[:historical_trend_data]
-    expect(historical_trend_data.keys.count).to eq(13)
+    historical_trend_data = IncomeCalculator.call(@account)[:historical_trend_data]
+    expect(historical_trend_data.keys.count).to eq(25)
+    expect(historical_trend_data.keys.first).to eq @account.first_transaction_occured_at.beginning_of_month
     this_month = Date.today.beginning_of_month
     expect(historical_trend_data[this_month]).to eq(100)
     expect(historical_trend_data[this_month - 1.month]).to eq(100)
@@ -18,18 +20,19 @@ RSpec.describe IncomeCalculator do
     expect(historical_trend_data[this_month - 4.month]).to eq(400)
     expect(historical_trend_data[this_month - 5.month]).to eq(0)
     expect(historical_trend_data[this_month - 1.year]).to eq(500)
+    expect(historical_trend_data[this_month - 2.year]).to eq(0)
   end
 
   it 'has a current value' do
-    expect(IncomeCalculator.call(@user.account)[:current_value]).to eq(1200)
+    expect(IncomeCalculator.call(@account)[:current_value]).to eq(1200)
   end
 
   it 'calculates the income last change trend' do
-    expect(IncomeCalculator.call(@user.account)[:last_change_data]).to be_empty
+    expect(IncomeCalculator.call(@account)[:last_change_data]).to be_empty
   end
 
   it 'has value over time data' do
-    value_over_time_data = IncomeCalculator.call(@user.account)[:value_over_time_data]
+    value_over_time_data = IncomeCalculator.call(@account)[:value_over_time_data]
     expect(value_over_time_data[Stat::THIS_MONTH]).to eq(100)
     expect(value_over_time_data[Stat::LAST_MONTH]).to eq(100)
     expect(value_over_time_data[Stat::QUARTERLY]).to eq(300)
@@ -41,11 +44,13 @@ RSpec.describe IncomeCalculator do
 
   def build_historical_transactions
     create(:transaction, occured_at: Date.today, amount: 100, user: @user)
+    create(:transaction, occured_at: Date.today, amount: 100, user: @user)
     create(:transaction, occured_at: Date.today, amount: -100, user: @user, category: @category)
     create(:transaction, occured_at: Date.today, amount: -100, user: @user)
     create(:transaction, occured_at: 1.month.ago, amount: -100, user: @user)
     create(:transaction, occured_at: 3.month.ago, amount: -100, user: @user)
     create(:transaction, occured_at: 4.month.ago, amount: -400, user: @user)
     create(:transaction, occured_at: 1.year.ago, amount: -500, user: @user)
+    create(:transaction, occured_at: 2.year.ago, amount: 500, user: @user)
   end
 end


### PR DESCRIPTION
From the backend we are passing in UTC date time string at the start of the day (e.g. 2020-01-01 00:00:00 UTC). When we build a Date object on the front end from this string, e.g. `new Date('2020-01-01 00:00:00 UTC')` it was returning `Tue Dec 31 2019 18:00:00 GMT-0600 (Central Standard Time)` as it was offsetting based on the local time zone for the browser. This is not correct as we want to ignore the timezone here. Instead of building the date this way, let's use the components of the date string and pass in the year, month, date to create the date object like `new Date(year, month, date)`